### PR TITLE
Add Python 3.9 to build-builder

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -15,14 +15,24 @@ RUN sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo && \
    
 # use node 10 as it's guaranteed to run on CentOS6
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
-    yum install -y devtoolset-10 python36 wget patch && \
+    yum install -y devtoolset-10 bzip2-devel libffi-devel patch wget zlib-devel && \
     wget -q https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-x64.tar.gz && \
     tar -xf node-v10.23.0-linux-x64.tar.gz && \ 
     rm node-v10.23.0-linux-x64.tar.gz && \
     ln -s /node-v10.23.0-linux-x64/bin/node /bin/node && \ 
     ln -s /node-v10.23.0-linux-x64/bin/npm /bin/npm 
 
+# Build and install Python 3.9 as a prerequisite for building Node.js 24
+RUN PYTHON_VERSION=3.9.22 && \
+    wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz && \
+    tar -xvf Python-$PYTHON_VERSION.tgz && \
+    cd Python-$PYTHON_VERSION && \
+    ./configure --prefix=/usr/local && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf Python-$PYTHON_VERSION.tgz Python-$PYTHON_VERSION
+
 # before building using this container you need to enable the right slc toolchain ie
 # scl enable devtoolset-8 '<your-build-command-here>'
 # or 'source /opt/rh/devtoolset-8/enable'
-

--- a/Dockerfile.centos7.arm64
+++ b/Dockerfile.centos7.arm64
@@ -15,13 +15,23 @@ RUN sed -i 's|mirror.centos.org/centos|vault.centos.org/altarch|g' /etc/yum.repo
 
 # use node 10 as it's guaranteed to run on CentOS6
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
-    yum install -y devtoolset-10 python36 wget patch && \
+    yum install -y devtoolset-10 bzip2-devel libffi-devel patch wget zlib-devel && \
     wget -q https://nodejs.org/dist/v10.23.0/node-v10.23.0-linux-arm64.tar.gz && \
     gunzip node-v10.23.0-linux-arm64.tar.gz && tar xf node-v10.23.0-linux-arm64.tar && rm node-v10.23.0-linux-arm64.tar && \
     ln -s /node-v10.23.0-linux-arm64/bin/node /bin/node && \ 
-    ln -s /node-v10.23.0-linux-arm64/bin/npm /bin/npm && \
-    ln -fs /usr/bin/python3 /usr/bin/python 
+    ln -s /node-v10.23.0-linux-arm64/bin/npm /bin/npm
+
+# Build and install Python 3.9 as a prerequisite for building Node.js 24
+RUN PYTHON_VERSION=3.9.22 && \
+    wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz && \
+    tar -xvf Python-$PYTHON_VERSION.tgz && \
+    cd Python-$PYTHON_VERSION && \
+    ./configure --prefix=/usr/local && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -rf Python-$PYTHON_VERSION.tgz Python-$PYTHON_VERSION && \
+    ln -fs /usr/bin/python3 /usr/bin/python
 
 # to buid using this container you need to enable the right slc toolchain ie
 # scl enable devtoolset-8 '<your-build-command-here>'
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,14 @@ jobs:
       xcodebuild -version
     displayName: 'Show Current Xcode Version'
     condition: contains(variables['Agent.JobName'], 'macos')
+  - script: |
+      sudo xcode-select -s /Applications/Xcode_16.2.app
+      xcodebuild -version
+      echo "Currently selected Xcode:"
+      xcode-select -p
+      xcodebuild -version
+    displayName: 'Select Xcode 16.2'
+    condition: contains(variables['Agent.JobName'], 'macos')
   - script: choco install nasm -fy
     displayName: Install Windows Assembler (NASM)
     condition: contains(variables['Agent.JobName'], 'windows')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,12 @@ jobs:
   #- script: choco install visualcpp-build-tools --version 14.0.25420.1 -fy && npm config set msvs_version 2015
   #  condition: contains(variables['Agent.JobName'], 'windows_2015')
   #  displayName: Install Windows build dependencies
+  - script: |
+      echo "Currently selected Xcode:"
+      xcode-select -p
+      xcodebuild -version
+    displayName: 'Show Current Xcode Version'
+    condition: contains(variables['Agent.JobName'], 'macos')
   - script: choco install nasm -fy
     displayName: Install Windows Assembler (NASM)
     condition: contains(variables['Agent.JobName'], 'windows')

--- a/build-builder.sh
+++ b/build-builder.sh
@@ -3,7 +3,7 @@ docker pull moby/buildkit:buildx-stable-1
 if [ $(docker buildx ls | grep js2bin-builder  | wc -l) -eq 0 ]; then
     docker buildx create --name js2bin-builder
 fi
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker run --rm --privileged tonistiigi/binfmt --install all
 docker buildx use js2bin-builder
 BUILDER_IMAGE_VERSION="3"
 ARCH=$(uname -m)

--- a/build-builder.sh
+++ b/build-builder.sh
@@ -6,6 +6,11 @@ fi
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 docker buildx use js2bin-builder
 BUILDER_IMAGE_VERSION="3"
+ARCH=$(uname -m)
+if [ "$ARCH" == "x86_64" ]; then
+    echo "WARNING: You are running on an x86_64 host. Cross-compiling Python for arm64 may result in build failures or inconsistent behavior."
+    echo "It is recommended to run this script on an arm64 host if possible."
+fi
 docker buildx build -t "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}-nonx64" --platform linux/arm64/v8 --push -f Dockerfile.centos7.arm64 .
-docker build -t "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}" -f Dockerfile.centos7 .
-docker push "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}"
+docker buildx build -t "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}" --platform linux/amd64 --push -f Dockerfile.centos7 .
+

--- a/build-builder.sh
+++ b/build-builder.sh
@@ -5,7 +5,7 @@ if [ $(docker buildx ls | grep js2bin-builder  | wc -l) -eq 0 ]; then
 fi
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 docker buildx use js2bin-builder
-BUILDER_IMAGE_VERSION="2"
+BUILDER_IMAGE_VERSION="3"
 docker buildx build -t "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}-nonx64" --platform linux/arm64/v8 --push -f Dockerfile.centos7.arm64 .
 docker build -t "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}" -f Dockerfile.centos7 .
 docker push "cribl/js2bin-builder:${BUILDER_IMAGE_VERSION}"


### PR DESCRIPTION
- Build and install Python 3.9 as a prerequisite for building Node.js 24
- Use buildx for both builds in build-builder.sh
- Allow builds on arm64 host instance