### PR TITLE
Update used NodeBuilder Image version

### DIFF
--- a/src/NodeBuilder.js
+++ b/src/NodeBuilder.js
@@ -72,7 +72,7 @@ class NodeJsBuilder {
     this.cacheDir = join(cwd || process.cwd(), 'cache');
     this.resultFile = isWindows ? join(this.nodeSrcDir, 'Release', 'node.exe') : join(this.nodeSrcDir, 'out', 'Release', 'node');
     this.placeHolderSizeMB = -1;
-    this.builderImageVersion = 2;
+    this.builderImageVersion = 3;
   }
 
   static platform() {


### PR DESCRIPTION
Requires updating the image in DockerHub: as mentioned here: https://github.com/avcribl/js2bin/pull/3